### PR TITLE
fix the way to get error details instead of .command.err

### DIFF
--- a/conf/test.config
+++ b/conf/test.config
@@ -26,6 +26,6 @@ params {
     // TODO nf-core: Specify the paths to your test data on nf-core/test-datasets
     // TODO nf-core: Give any required params for the test so that command line flags are not needed
     // input  = params.pipelines_testdata_base_path + 'viralrecon/samplesheet/samplesheet_test_illumina_amplicon.csv'
-    //allow_duplicates = true
+    allow_duplicates = true
 
 }

--- a/modules/local/score/upload/main.nf
+++ b/modules/local/score/upload/main.nf
@@ -61,15 +61,15 @@ process SCORE_UPLOAD {
         export TRANSPORT_PARALLEL=${transport_parallel}
         export TRANSPORT_MEM=${transport_mem}
 
-        # Execute SCORE upload
-        score-client upload --manifest ${manifest} $args
+        # Execute SCORE upload and capture stderr directly
+        ERROR_OUTPUT=\$(score-client upload --manifest ${manifest} $args 2>&1)
         UPLOAD_EXIT_CODE=\${?}
         
         if [ \${UPLOAD_EXIT_CODE} -ne 0 ]; then
-            # Capture error details, converting carriage returns to newlines and filtering for ERROR lines
-            if [ -f ".command.err" ] && [ -s ".command.err" ]; then
+            # Process the captured error output
+            if [ -n "\${ERROR_OUTPUT}" ]; then
                 # Convert carriage returns to newlines, then get lines containing ERROR
-                ERROR_DETAILS=\$(tr '\\r' '\\n' < ".command.err" | grep "ERROR" || echo "No ERROR lines found")
+                ERROR_DETAILS=\$(echo "\${ERROR_OUTPUT}" | tr '\\r' '\\n' | grep "ERROR" || echo "\${ERROR_OUTPUT}")
             else
                 ERROR_DETAILS="Script execution failed - no error details available"
             fi

--- a/modules/local/song/manifest/main.nf
+++ b/modules/local/song/manifest/main.nf
@@ -61,14 +61,14 @@ process SONG_MANIFEST {
         export CLIENT_STUDY_ID=${study_id}
         export CLIENT_ACCESS_TOKEN=${accessToken}
 
-        # Execute SONG manifest generation
-        sing manifest -a \${ANALYSIS_ID} -d . -f ${manifest_file} $args
+        # Execute SONG manifest generation and capture stderr directly
+        ERROR_OUTPUT=\$(sing manifest -a \${ANALYSIS_ID} -d . -f ${manifest_file} $args 2>&1)
         MANIFEST_EXIT_CODE=\${?}
         
         if [ \${MANIFEST_EXIT_CODE} -ne 0 ]; then
-            # Capture error details preserving original formatting
-            if [ -f ".command.err" ] && [ -s ".command.err" ]; then
-                ERROR_DETAILS=\$(cat ".command.err")
+            # Process the captured error output
+            if [ -n "\${ERROR_OUTPUT}" ]; then
+                ERROR_DETAILS=\$(echo "\${ERROR_OUTPUT}" | tr '\\r' '\\n' | grep "ERROR" || echo "\${ERROR_OUTPUT}")
             else
                 ERROR_DETAILS="Script execution failed - no error details available"
             fi

--- a/modules/local/song/publish/main.nf
+++ b/modules/local/song/publish/main.nf
@@ -57,14 +57,14 @@ process SONG_PUBLISH {
         export CLIENT_STUDY_ID=${study_id}
         export CLIENT_ACCESS_TOKEN=${accessToken}
 
-        # Execute SONG publish
-        sing publish -a \${ANALYSIS_ID} $args
+        # Execute SONG publish and capture stderr directly
+        ERROR_OUTPUT=\$(sing publish -a \${ANALYSIS_ID} $args 2>&1)
         PUBLISH_EXIT_CODE=\${?}
         
         if [ \${PUBLISH_EXIT_CODE} -ne 0 ]; then
-            # Capture error details preserving original formatting
-            if [ -f "song.log" ] && [ -s "song.log" ]; then
-                ERROR_DETAILS=\$(cat "song.log")
+            # Process the captured error output
+            if [ -n "\${ERROR_OUTPUT}" ]; then
+                ERROR_DETAILS=\$(echo "\${ERROR_OUTPUT}" | tr '\\r' '\\n' | grep "ERROR" || echo "\${ERROR_OUTPUT}")
             else
                 ERROR_DETAILS="Script execution failed - no error details available"
             fi


### PR DESCRIPTION
Some modules tried to retrieve error messages from .command.err which is not appropriate. 
I have changed them to get error details from stderr output from the command. 