### PR TITLE
fix skip_upload flag

### DIFF
--- a/modules/local/payload/validate/main.nf
+++ b/modules/local/payload/validate/main.nf
@@ -38,7 +38,7 @@ process PAYLOAD_VALIDATE {
     def exit_on_error = task.ext.exit_on_error ?: false
     def exit_on_error_str = exit_on_error.toString()
     def schema_url = "${params.file_manager_url}/schemas"
-    def skip_external = params.skip_upload!=null ? "--skip-external" : ""
+    def skip_external = params.skip_upload ? "--skip-external" : ""
     if (!schema_url) {
         error "schema_url must be provided via task.ext.schema_url"
     }

--- a/tests/test_data/analysis_meta/PCGLST0007_bad_experiment_analysis_metadata.tsv
+++ b/tests/test_data/analysis_meta/PCGLST0007_bad_experiment_analysis_metadata.tsv
@@ -1,0 +1,6 @@
+studyId	submitter_analysis_id	analysisType	submitter_participant_id	submitter_specimen_id	submitter_sample_id	submitter_experiment_id	data_category	variant_class	variant_calling_strategy	genome_build	genome_annotation
+PCGLST0007	analysis_001	sequenceExperiment	PART_001	SPEC_001	SAMPLE_001	EXP_001A	Genomics				
+PCGLST0007	analysis_002	sequenceAlignment	PART_002	SPEC_002	SAMPLE_002	EXP_002A	Genomics			GRCh38	
+PCGLST0007	analysis_003	variantCall	PART_003	SPEC_003	SAMPLE_003	EXP_003A	Genomics	Germline	Single sample	GRCh38	GENCODE v38
+PCGLST0007	analysis_004	sequenceAlignment	PART_004	SPEC_004	SAMPLE_004	EXP_004A	Genomics			GRCh38	GENCODE v38
+PCGLST0007	analysis_005	sequenceExperiment	PART_004	SPEC_004	SAMPLE_004	EXP_005A	Genomics			GRCh38	GENCODE v38


### PR DESCRIPTION
- skip_upload was being evaluated incorrectly resulting in external ID checks being skipped by default

TESTING:
- default should be enforcing external ID check
```
nextflow run . \
--study_id PCGLST0007 \
--file_metadata tests/test_data/analysis_meta/file_metadata.tsv \
--workflow_metadata tests/test_data/analysis_meta/workflow_metadata.tsv \
--analysis_metadata tests/test_data/analysis_meta/PCGLST0007_analysis_metadata.tsv \
--outdir test_minimal -profile test,docker,sd4h_staging \
--token ${token} \
--path_to_files_directory ./tests/test_data/genomics/
```
-- result should be:
```
 ✅ Successful submissions: 0
 ❌ Failed submissions:     5
```
- default should be enforcing external ID check
```
nextflow run . \
--study_id PCGLST0007 \
--file_metadata tests/test_data/analysis_meta/file_metadata.tsv \
--workflow_metadata tests/test_data/analysis_meta/workflow_metadata.tsv \
--analysis_metadata tests/test_data/analysis_meta/PCGLST0007_analysis_metadata.tsv \
--outdir test_minimal -profile test,docker,sd4h_staging \
--token ${token} \
--path_to_files_directory ./tests/test_data/genomics/
--skip_upload
```
-- result should be:
```
 ✅ Successful submissions: 1
 ❌ Failed submissions:     4
```