### PR TITLE
update bcftools and seqtools

### DIFF
--- a/modules/local/bcftools/view/main.nf
+++ b/modules/local/bcftools/view/main.nf
@@ -35,14 +35,15 @@ process BCFTOOLS_VIEW {
     else
         echo "Running bcftools view validation on: ${vcf_file}"
         # Execute bcftools view and capture stderr directly
-        ERROR_OUTPUT=\$(bcftools view --no-header "${vcf_file}" 2>&1)
+        # ERROR_OUTPUT=\$(bcftools view --no-header "${vcf_file}" 2>&1)
+        ERROR_OUTPUT=\$(bcftools view --no-header "${vcf_file}" > /dev/null 2> error.log)
         VCF_EXIT_CODE=\$?
         
         if [ \${VCF_EXIT_CODE} -ne 0 ]; then
             # Process the captured error output
-            if [ -n "\${ERROR_OUTPUT}" ]; then
+            if [ -n "\$(cat error.log)" ]; then
                 # Remove ANSI color codes, carriage returns, and filter out empty lines
-                ERROR_DETAILS=\$(echo "\${ERROR_OUTPUT}" | sed 's/\\x1b\\[[0-9;]*m//g' | tr '\\r' '\\n' | grep -v '^[[:space:]]*\$' || echo "\${ERROR_OUTPUT}")
+                ERROR_DETAILS=\$(cat error.log | sed 's/\\x1b\\[[0-9;]*m//g' | tr '\\r' '\\n' | grep -v '^[[:space:]]*\$' || echo "\${ERROR_OUTPUT}")
             else
                 ERROR_DETAILS="VCF file ${vcf_file}: Failed bcftools view validation"
             fi

--- a/modules/local/seqkit/seq/main.nf
+++ b/modules/local/seqkit/seq/main.nf
@@ -35,14 +35,14 @@ process SEQKIT_SEQ {
     else
         echo "Running seqkit seq validation on: ${fastq_file}"
         # Execute seqkit seq and capture stderr directly
-        ERROR_OUTPUT=\$(seqkit seq -j ${task.cpus} --validate-seq "${fastq_file}" --quiet -o /dev/null 2>/dev/null)
+        ERROR_OUTPUT=\$(seqkit seq -j ${task.cpus} --validate-seq "${fastq_file}" --quiet -o /dev/null 2> error.log)
         FASTQ_EXIT_CODE=\$?
         
         if [ \${FASTQ_EXIT_CODE} -ne 0 ]; then
             # Process the captured error output
-            if [ -n "\${ERROR_OUTPUT}" ]; then
+            if [ -n "\$(cat error.log)" ]; then
                 # Remove ANSI color codes and clean up formatting
-                ERROR_DETAILS=\$(echo "\${ERROR_OUTPUT}" | tr -d '\\033' | sed 's/\\[[0-9;]*m//g' | tr '\\r' '\\n' | grep -v '^[[:space:]]*\$' || echo "\${ERROR_OUTPUT}")
+                ERROR_DETAILS=\$(cat error.log | tr -d '\\033' | sed 's/\\[[0-9;]*m//g' | tr '\\r' '\\n' | grep -v '^[[:space:]]*\$' || echo "\${ERROR_OUTPUT}")
             else
                 ERROR_DETAILS="FASTQ file ${fastq_file}: Failed seqkit seq validation"
             fi

--- a/tests/test_data/analysis_meta/trouble_file_metadata.tsv
+++ b/tests/test_data/analysis_meta/trouble_file_metadata.tsv
@@ -8,3 +8,4 @@ analysis_005	test_sample_R1.fastq.gz	85	a1505aad2f04bd9594f43745ee5ee4a5	FASTQ	c
 analysis_005	test_sample_R2.fastq.gz	87	38a41f5dbf5f1e1e09fb3024555ede4e	FASTQ	controlled	Raw Sequencing Reads
 analysis_003	test_variants.gvcf.gz	479	9a2d5034845272d32ea829cb29552073	VCF	controlled	Single Nucleotide Variants (SNVs)
 analysis_003	test_variants.gvcf.gz.tbi	149	a76295ab7aede4ce116c9e359b0d8719	TBI	controlled	Single Nucleotide Variants (SNVs) Index
+analysis_003	HG002_GRCh38_1_22_v4.2.1_benchmark.vcf			VCF	controlled	Single Nucleotide Variants (SNVs)


### PR DESCRIPTION
- bcftools will error out b/c it streams all data within RAM, output to `/dev/null` and redirect errors to log. Read logs
- Seqkit has a similar issue, where previously addressed. Fix was incompete as per https://github.com/Pan-Canadian-Genome-Library/molecular-data-submission-workflow/issues/84

To test
A) Need to retrieve a large VCF file:
```
curl -C - -O https://ftp-trace.ncbi.nlm.nih.gov/ReferenceSamples/giab/release/AshkenazimTrio/HG002_NA24385_son/NISTv4.2.1/GRCh38/HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
gunzip HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz
mv HG002_GRCh38_1_22_v4.2.1_benchmark.vcf.gz tests/test_data/genomics
```
B) Testing
```
nextflow run . \
--study_id PCGLST0007 \
--file_metadata tests/test_data/analysis_meta/trouble_file_metadata.tsv \
--workflow_metadata tests/test_data/analysis_meta/workflow_metadata.tsv \
--analysis_metadata tests/test_data/analysis_meta/PCGLST0007_analysis_metadata.tsv \
--outdir test_minimal -profile test,docker,sd4h_staging \
--path_to_files_directory /Users/esu/Desktop/GitHub/pcgl/molecular-data-submission-workflow/tests/test_data/genomics/ \
--skip_upload
```